### PR TITLE
Update 0161_eux.yaml - IPA

### DIFF
--- a/cards/0161_eux.yml
+++ b/cards/0161_eux.yml
@@ -6,7 +6,7 @@ Wortart: pro
 # Diese Felder gerne verbessern!
 Wort mit Artikel: eux
 Femininum / Plural: elles
-IPA: \lɥi\
+IPA: \ø\
 Definition: sie [Plural]
 Register: '' # Beispiel: ↘Sachtext ↗Mündlich
 Beispielsätze: "C’est eux qui comptent.\nAuf sie kommt es an.\n\nJe les ai vus partir\


### PR DESCRIPTION
Das Wort "eux" wird [ø] ausgesprochen. Die Audio stimmt, aber die Lautschrift nicht.