### PR TITLE
Add config option for Audio lang in cloze game on backsides

### DIFF
--- a/ankiweb_listing.html
+++ b/ankiweb_listing.html
@@ -75,6 +75,7 @@ Auf der Rückseite der Karte kannst du folgende Optionen einstellen (jeweils fü
 <ul>
 <li><code>hideSpoilers</code>: Standardmäßig wird die Übersetzung von Sätzen ausgeblendet und kann durch ein Klicken angezeigt werden. Wenn die Übersetzung standardmäßig angezeigt werden soll, setze den Wert auf <code>false</code>.</li>
 <li><code>autoPlaySentence</code>: Ob der erste Beispielsatz automatisch abgespielt werden soll. Mit <code>autoPlaySentenceInGerman</code> kann der Satz auf Deutsch vorgelesen werden.</li>
+<li><code>autoPlaySentenceOnClozeFinish</code>: Ob der Beispielsatz automatisch vorgelesen werden soll, wenn das Lückenspiel fertig gespielt wurde. Mit <code>autoPlaySentenceOnClozeFinishInGerman</code> kann der Satz auf Deutsch vorgelesen werden.</li>
 <li><code>tenses</code>: Welche Konjugationen in der Tabelle angezeigt werden sollen.</li>
 </ul>
 

--- a/card_templates/back.html
+++ b/card_templates/back.html
@@ -14,6 +14,9 @@ var options = {
   /* Ob der Beispielsatz vorgelesen werden soll, wenn das Lückenspiel gespielt wurde. */
   "autoPlaySentenceOnClozeFinish": true,
 
+  /* Ob der Beispielsatz nach dem Lückenspiel auf Deutsch vorgelesen werden soll. */
+  "autoPlaySentenceOnClozeFinishInGerman": false,
+
   /* Verzögerung in Millisekunden, bevor der erste Beispielsatz automatisch abgespielt wird. */
   "autoPlaySentenceDelay": 1000,
 

--- a/card_templates/back.js
+++ b/card_templates/back.js
@@ -124,6 +124,9 @@ function refreshExampleSentences() {
       sentence: frenchFirst
         ? processText(de, false, false)
         : processText(fr, true, false),
+      sentenceToRead: options.autoPlaySentenceOnClozeFinishInGerman
+        ? processText(de, false, false)
+        : processText(fr, true, false),
       gameContainer,
       isGerman: frenchFirst,
       showOverlay: false


### PR DESCRIPTION
This PR concerns the cloze game initiated from the backside of the cars. 

Current default and unconfigurable behavior is to play german audio synthesized by the french voice when the cloze game is solved.

This PR implements a config option for the audio language on cloze finish. The default behavior is changed so to play french audio by default, reflecting the scope of the project.

Thank you for your valuable work, this project is beautiful!

All the best
kesatz