### PR TITLE
Definition zu "car" hinzugefügt und zu "bus" abgegrenzt

### DIFF
--- a/cards/0176_car.yml
+++ b/cards/0176_car.yml
@@ -7,7 +7,7 @@ Wortart: nm, conj
 Wort mit Artikel: car
 Femininum / Plural: ''
 IPA: \kaʁ\
-Definition: denn, da
+Definition: denn, da; (Reise-)Bus
 Register: '' # Beispiel: ↘Sachtext ↗Mündlich
 
 # Beispielsätze müssen durch Zeilenumbrüche getrennt werden.
@@ -69,4 +69,11 @@ Beispielsätze: |-
 #   <div class="fr">Un homme et une femme.</div>
 #   <div class="de spoiler">Ein Mann und eine Frau.</div>
 # </div>
-Notiz: ''
+Notiz: |-
+<grammar data-id="Transport"></grammar>
+<div class="section">
+    <div class="section-title"><i>car</i> und <i>bus</i></div>
+    <div class="section-content">
+      <p><b>Car</b> meint Schul- oder Reisebusse oder Mannschaftswägen, während <b>bus</b> (#4027) Linienbusse meint.</p>
+    </div>
+  </div>

--- a/cards/0176_car.yml
+++ b/cards/0176_car.yml
@@ -7,7 +7,7 @@ Wortart: nm, conj
 Wort mit Artikel: car
 Femininum / Plural: ''
 IPA: \kaʁ\
-Definition: denn, da; (Reise-)Bus
+Definition: denn, da
 Register: '' # Beispiel: ↘Sachtext ↗Mündlich
 
 # Beispielsätze müssen durch Zeilenumbrüche getrennt werden.

--- a/cards/4027_bus.yml
+++ b/cards/4027_bus.yml
@@ -7,7 +7,7 @@ Wortart: nm
 Wort mit Artikel: le bus
 Femininum / Plural: ''
 IPA: \bys\
-Definition: Bus
+Definition: (Linien-)Bus
 Register: '' # Beispiel: ↘Sachtext ↗Mündlich
 
 # Beispielsätze müssen durch Zeilenumbrüche getrennt werden.
@@ -69,4 +69,11 @@ Beispielsätze: |-
 #   <div class="fr">Un homme et une femme.</div>
 #   <div class="de spoiler">Ein Mann und eine Frau.</div>
 # </div>
-Notiz: <grammar data-id="Transport"></grammar>
+Notiz: |-
+<grammar data-id="Transport"></grammar>
+<div class="section">
+    <div class="section-title"><i>car</i> und <i>bus</i></div>
+    <div class="section-content">
+      <p><b>Car</b> meint Schul- oder Reisebusse oder Mannschaftswägen, während <b>bus</b> (#4027) Linienbusse meint.</p>
+    </div>
+  </div>

--- a/cards/4027_bus.yml
+++ b/cards/4027_bus.yml
@@ -7,7 +7,7 @@ Wortart: nm
 Wort mit Artikel: le bus
 Femininum / Plural: ''
 IPA: \bys\
-Definition: (Linien-)Bus
+Definition: Bus
 Register: '' # Beispiel: ↘Sachtext ↗Mündlich
 
 # Beispielsätze müssen durch Zeilenumbrüche getrennt werden.


### PR DESCRIPTION
"le car" wird in den Beispielsätze verwendet kommt aber nicht in der Definition vor.
Zudem Notiz zu car und bus hinzugefügt