### PR TITLE
y als Buchstabe statt das Wort weg.yml

### DIFF
--- a/cards/0036_y.yml
+++ b/cards/0036_y.yml
@@ -31,15 +31,6 @@ Beispielsätze: |-
   "Regarde ce tableau, c'est-*y* pas magnifique ?"
   "Schau dir dieses Gemälde an, ist es nicht wunderschön?"
 
-  Le chromosome *Y* est présent chez les mammifères mâles.
-  Das *Y*-Chromosom ist bei männlichen Säugetieren vorhanden.
-
-  En mathématiques, l'axe des *y* représente les ordonnées.
-  In der Mathematik stellt die *y*-Achse die Ordinaten dar.
-
-  *Y* est le symbole chimique de l'yttrium.
-  *Y* ist das chemische Symbol für Yttrium.
-
   Allons-*y*, le film va bientôt commencer !
   Lass uns *losgehen*, der Film fängt bald an!
 
@@ -96,9 +87,6 @@ Beispielsätze: |-
 
   Le *y* est la vingt-cinquième lettre de l'alphabet français.
   Das *Y* ist der fünfundzwanzigste Buchstabe des französischen Alphabets.
-
-  La route forme un *Y* à cet endroit.
-  Die Straße bildet an dieser Stelle ein *Y*.
 
   Je n'*y* comprends rien à cette nouvelle loi.
   Ich verstehe *nichts* von diesem neuen Gesetz.


### PR DESCRIPTION
y-chromosom
y Kreuzung
und y Achse sind nicht repräsentative Satzbeispiele ;)