### PR TITLE
Unverbundene Personanlpronomen Beispielsatz verdeutlichen 

### DIFF
--- a/grammar/3 Pronomen/02 UnverbundenePersonalpronomen.html
+++ b/grammar/3 Pronomen/02 UnverbundenePersonalpronomen.html
@@ -71,8 +71,8 @@
 
     <li>nach <span class="fr">c’est</span> und <span class="fr">ce sont</span>:</li>
     <div class="examples">
-      <div class="fr">Qui a organisé cette fête ? C’est <span class="fr">elle</span> qui a tout organisé.</div>
-      <div class="de spoiler">Wer hat diese Party organisiert? Sie hat alles organisiert.</div>
+      <div class="fr">Qui a organisé cette fête ? C’est <span class="fr">lui</span> qui a tout organisé.</div>
+      <div class="de spoiler">Wer hat diese Party organisiert? Er hat alles organisiert.</div>
     </div>
 
     <li>beim bejahten Imperativ:</li>


### PR DESCRIPTION
Da _elle_ sowohl verbunden als auch unverbunden sein kann, ist das nicht eindeutig ein Beispiel für unverbundene Personalpronomen. Deshalb habe ich _elle_ mit _lui_ ersetzt.