### PR TITLE
Fix formatting in 0026_son.yml

### DIFF
--- a/cards/0026_son.yml
+++ b/cards/0026_son.yml
@@ -151,8 +151,8 @@ Beispielsätze: |-
   L'artiste a perdu de *son* influence dans le monde de l'art moderne.
   Der Künstler hat etwas von *seinem* Einfluss in der modernen Kunstwelt verloren.
 
-  Le cuisinier a ajouté du *son* d'avoine à *sa* recette de cookies.
-  Der Koch hat *seiner* Keksrezeptur *Hafer*kleie hinzugefügt.
+  Le cuisinier a ajouté du *son* d'avoine à sa recette de cookies.
+  Der Koch hat *seiner* Keksrezeptur Haferkleie hinzugefügt.
 
   *Ses* yeux brillaient de joie en voyant le cadeau.
   *Ihre* Augen leuchteten vor Freude, als sie das Geschenk sah.


### PR DESCRIPTION
Removed unnecessary asterisk from the word 'Haferkleie' in the German translation.